### PR TITLE
Added Accountmanager submodule & docker-compose

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+start.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+client-files/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 client-files/*
+server/
+.env

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "AccountManager"]
+	path = AccountManager
+	url = https://github.com/Denperidge/AccountManager.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,5 +47,5 @@ RUN mkdir -p /server/logs
 
 # Set the start script as entrypoint
 COPY start.sh start.sh
-ENTRYPOINT /server/start.sh
+ENTRYPOINT [ "/bin/bash", "/server/start.sh" ]
 

--- a/Readme.md
+++ b/Readme.md
@@ -108,7 +108,7 @@ services:
     image: mariadb
     container_name: darkflameserver-db
     command: --default-authentication-plugin=mysql_native_password
-    restart: always
+    restart: unless-stopped
     environment:
       MYSQL_ROOT_PASSWORD: "MySecretRootPW"
     volumes:
@@ -122,13 +122,13 @@ services:
   darkflameserver:
     image: darkflameserver
     container_name: darkflameserver
-    restart: always
+    restart: unless-stopped
     tty: true
     stop_grace_period: 2m
     depends_on:
-      - luni-db
+      - darkflameserver-db
     environment:
-      MYSQL_HOST: luni-db
+      MYSQL_HOST: darkflameserver-db
       MYSQL_DATABASE: luniserver_net
       MYSQL_USERNAME: root
       MYSQL_PASSWORD: MySecretRootPW

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,58 @@
+version: "2.2"
+services:
+# Darkflame LEGO Universe server
+# Database
+  darkflameserver-db:
+    image: mariadb
+    container_name: darkflameserver-db
+    command: --default-authentication-plugin=mysql_native_password
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: mysql_darkflame_password
+    volumes:
+      -  ${MY_DATABASE_FOLDER}:/var/lib/mysql
+    networks:
+      darkflameserver-net:
+    ports:
+      - 3306:3306/tcp
+
+# Server
+  darkflameserver:
+    build:
+      context: .
+    container_name: darkflameserver
+    restart: unless-stopped
+    tty: true
+    stop_grace_period: 2m
+    depends_on:
+      - darkflameserver-db
+    environment:
+      MYSQL_HOST: darkflameserver-db
+      MYSQL_DATABASE: luniserver_net
+      MYSQL_USERNAME: root
+      MYSQL_PASSWORD: mysql_darkflame_password
+    volumes:
+      -  ${MY_CONFIG_FOLDER}:/config
+    networks:
+      darkflameserver-net:
+    ports:
+      - 1001:1001/udp
+      - 2000-2200:2000-2200/udp
+      - 3000-3200:3000-3200/udp
+    
+  
+  # Accountmanager
+  darkflameaccountmanager:
+    build:
+      context: ./AccountManager
+    container_name: darkflameserver-accountmanage
+    depends_on:
+      - darkflameserver-db
+    ports:
+      - 5000:5000/tcp 
+    networks:
+      darkflameserver-net:
+
+networks:
+  darkflameserver-net:
+    driver: bridge


### PR DESCRIPTION
Okay these are some old commits, but I thought I'd PR them your way in case you wanted them!
Some of the changes:
- Adding AccountManager as a submodule
- Adding AccountManager to the docker-compose
- Switching Docker-Compose restart behaviour to "unless-stopped"
- gitattributes enforcing LF line endings

Feel free to keep some, all, or none of the changes! Either way, have a nice day!

(Not unrelated: the submodule is of my fork, which is now out of date. It only had a minor change as seen in https://github.com/DarkflameUniverse/AccountManager/commit/ea93ddbb4d50e1bddc0ba601f8a423a40715c7f4, but I don't recall how essential this was)